### PR TITLE
nsqadmin: failed to delete ephemeral topic

### DIFF
--- a/nsqadmin/templates/channel.html.go
+++ b/nsqadmin/templates/channel.html.go
@@ -8,7 +8,7 @@ func init() {
 
 <ul class="breadcrumb">
   <li><a href="/">Streams</a> <span class="divider">/</span></li>
-  <li><a href="/topic/{{.Topic}}">{{.Topic}}</a> <span class="divider">/</span></li>
+  <li><a href="/topic/{{.Topic | urlquery}}">{{.Topic}}</a> <span class="divider">/</span></li>
   <li class="active">{{.Channel}}</li>
 </ul>
 

--- a/nsqadmin/templates/index.html.go
+++ b/nsqadmin/templates/index.html.go
@@ -21,9 +21,9 @@ func init() {
     </tr>
 {{range $t := .Topics}}
     <tr>
-        <td><a href="/topic/{{.TopicName}}">{{.TopicName}}</a></td>
-        {{if $g.Enabled}}<td><a href="/topic/{{.TopicName}}"><img width="120" height="20" src="{{$g.Sparkline $t "depth"}}"></a></td>{{end}}
-        {{if $g.Enabled}}<td><a href="/topic/{{.TopicName}}"><img width="120" height="20" src="{{$g.Sparkline $t "message_count"}}"></a></td>{{end}}
+        <td><a href="/topic/{{.TopicName | urlquery}}">{{.TopicName}}</a></td>
+        {{if $g.Enabled}}<td><a href="/topic/{{.TopicName | urlquery}}"><img width="120" height="20" src="{{$g.Sparkline $t "depth"}}"></a></td>{{end}}
+        {{if $g.Enabled}}<td><a href="/topic/{{.TopicName | urlquery}}"><img width="120" height="20" src="{{$g.Sparkline $t "message_count"}}"></a></td>{{end}}
         {{if $g.Enabled}}<td class="bold rate" target="{{$g.Rate $t}}"></td> {{end}}
     </tr>
 {{end}}

--- a/nsqadmin/templates/lookup.html.go
+++ b/nsqadmin/templates/lookup.html.go
@@ -41,7 +41,7 @@ func init() {
             <li><form class="form-inline" style="margin:0" action="/delete_topic" method="POST">
                     <input type="hidden" name="rd" value="/lookup">
                     <input type="hidden" name="topic" value="{{$t}}">
-                    <button class="btn btn-mini btn-link red" type="submit">✘</button><a href="/topic/{{$t}}">{{$t}}</a>
+                    <button class="btn btn-mini btn-link red" type="submit">✘</button><a href="/topic/{{$t | urlquery}}">{{$t}}</a>
                 </form>
                 <ul>
                     {{range $channels}}
@@ -49,7 +49,7 @@ func init() {
                         <input type="hidden" name="rd" value="/lookup">
                         <input type="hidden" name="topic" value="{{$t}}">
                         <input type="hidden" name="channel" value="{{.}}">
-                        <button class="btn btn-mini btn-link red" type="submit">✘</button><a href="/topic/{{$t}}/{{.}}">{{.}}</a>
+                        <button class="btn btn-mini btn-link red" type="submit">✘</button><a href="/topic/{{$t | urlquery}}/{{. | urlquery}}">{{.}}</a>
                     </form></li>
                     {{end}}
                 </ul>

--- a/nsqadmin/templates/nodes.html.go
+++ b/nsqadmin/templates/nodes.html.go
@@ -41,7 +41,7 @@ func init() {
         {{if .Topics}}
             <span class="badge">{{.Topics | len}}</span>
             {{range .Topics}}
-            <a href="/topic/{{.Topic}}" class="label {{if .Tombstoned}}label-important{{else}}label-info{{end}}" {{if .Tombstoned}}title="this topic is currently tombstoned on this node"{{end}}>{{.Topic}}</a>
+            <a href="/topic/{{.Topic | urlquery}}" class="label {{if .Tombstoned}}label-important{{else}}label-info{{end}}" {{if .Tombstoned}}title="this topic is currently tombstoned on this node"{{end}}>{{.Topic}}</a>
             {{end}}
         {{end}}
         </td>

--- a/nsqadmin/templates/topic.html.go
+++ b/nsqadmin/templates/topic.html.go
@@ -194,7 +194,7 @@ func init() {
 
 {{range $c := .ChannelStats}}
     <tr >
-        <th><a href="/topic/{{$c.TopicName}}/{{$c.ChannelName | urlquery}}">{{$c.ChannelName}}</a> 
+        <th><a href="/topic/{{$c.TopicName | urlquery}}/{{$c.ChannelName | urlquery}}">{{$c.ChannelName}}</a> 
             {{if $c.Paused}}<span class="label label-important">paused</span>{{end}}
             </th>
         <td>


### PR DESCRIPTION
So I have created three ephemeral topics :

![screenshot from 2015-01-08 15 11 55](https://cloud.githubusercontent.com/assets/10451281/5664562/1fc16714-9749-11e4-8c5f-7a3fc5c57a8a.png)

Then just clicked in one of them: 

![screenshot from 2015-01-08 15 12 27](https://cloud.githubusercontent.com/assets/10451281/5664579/3c0c1784-9749-11e4-839a-1a8e9004969c.png)

Then press to delete that topic:

![screenshot from 2015-01-08 15 12 59](https://cloud.githubusercontent.com/assets/10451281/5664584/48853798-9749-11e4-843c-07361d39c29e.png)

but surprisingly the topic is still there:

![screenshot from 2015-01-08 15 17 01](https://cloud.githubusercontent.com/assets/10451281/5664601/78243e36-9749-11e4-9f22-9b2fcc70a453.png)

Also one more thing I saw that is even after shutdown completely all nsq services and restarting it, I could still see those three topics.




 