### PR TITLE
nsqd.cfg.example: to change the worker_id it should just be id

### DIFF
--- a/contrib/nsqd.cfg.example
+++ b/contrib/nsqd.cfg.example
@@ -2,7 +2,7 @@
 verbose = false
 
 ## unique identifier (int) for this worker (will default to a hash of hostname)
-# worker_id = 5150
+# id = 5150
 
 ## <addr>:<port> to listen on for TCP clients
 tcp_address = "0.0.0.0:4150"


### PR DESCRIPTION
The configuration file option for worker_id should just be id