### PR TITLE
dist: single versioned Dockerfile approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
-FROM google/golang:latest
+FROM scratch
 
-RUN curl -s https://raw.githubusercontent.com/pote/gpm/v1.2.3/bin/gpm > /usr/local/bin/gpm
-RUN chmod +x /usr/local/bin/gpm
+ADD dist/docker/bin/ /
 
-ADD . $GOPATH/src/github.com/bitly/nsq
-RUN cd $GOPATH/src/github.com/bitly/nsq && gpm install
-RUN go get github.com/bitly/nsq/...
-
-RUN cd $GOPATH/src/github.com/bitly/nsq && ./test.sh
+VOLUME /etc/ssl/certs

--- a/apps/nsqd/Dockerfile
+++ b/apps/nsqd/Dockerfile
@@ -1,8 +1,0 @@
-FROM nsqio/deprecated_nsq_base:latest
-
-RUN cd /gopath/src/github.com/bitly/nsq/apps/nsqd && go build .
-VOLUME ["/data"]
-EXPOSE 4150
-EXPOSE 4151
-
-ENTRYPOINT ["/gopath/src/github.com/bitly/nsq/apps/nsqd/nsqd", "--data-path=/data"]

--- a/apps/nsqd/README.md
+++ b/apps/nsqd/README.md
@@ -3,20 +3,3 @@
 `nsqd` is the daemon that receives, queues, and delivers messages to clients.
 
 Read the [docs](http://nsq.io/components/nsqd.html).
-
-### Docker
-
-1. Pull down this image:
-
-        docker pull nsqio/nsqd
-
-2. Run the image:
-
-        docker run --name nsqd -p 4150:4150 -p 4151:4151
-            nsqio/nsqd 
-            --broadcast-address=<host> 
-            --lookupd-tcp-address=<host>:<port>
-
-Take a look at the [NSQ docker documentation](http://nsq.io/deployment/docker.html) to see how this
-can be used with the official [nsqlookupd](https://registry.hub.docker.com/u/nsqio/nsqlookupd/)
-image.

--- a/apps/nsqlookupd/Dockerfile
+++ b/apps/nsqlookupd/Dockerfile
@@ -1,7 +1,0 @@
-FROM nsqio/deprecated_nsq_base:latest
-
-RUN cd /gopath/src/github.com/bitly/nsq/apps/nsqlookupd && go build .
-EXPOSE 4160
-EXPOSE 4161
-
-ENTRYPOINT ["/gopath/src/github.com/bitly/nsq/apps/nsqlookupd/nsqlookupd"]

--- a/apps/nsqlookupd/README.md
+++ b/apps/nsqlookupd/README.md
@@ -4,16 +4,3 @@
 discover the location of topics at runtime.
 
 Read the [docs](http://nsq.io/components/nsqlookupd.html).
-
-### Docker
-
-1. Pull down this image:
-
-        docker pull nsqio/nsqlookupd
-
-2. Run the image:
-
-        docker run --name nsqlookupd -p 4160:4160 -p 4161:4161 nsqio/nsqlookupd
-
-Take a look at the [NSQ docker documentation](http://nsq.io/deployment/docker.html) to see how this
-can be used with the official [nsqd](https://registry.hub.docker.com/u/nsqio/nsqd/) image.

--- a/dist.sh
+++ b/dist.sh
@@ -7,6 +7,8 @@ set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p $DIR/dist
+rm -rf $DIR/dist/docker
+mkdir -p $DIR/dist/docker
 
 mkdir -p $DIR/.godeps
 export GOPATH=$DIR/.godeps:$GOPATH
@@ -27,8 +29,10 @@ for os in linux darwin; do
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 make
     make DESTDIR=$BUILD/$TARGET PREFIX= install
     pushd $BUILD
+    if [ "$os" == 'linux' ]; then cp -r $BUILD/$TARGET/bin $DIR/dist/docker/; fi
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist
     popd
     make clean
 done
+docker build -t nsqio/nsq:v$version .

--- a/nsqadmin/Dockerfile
+++ b/nsqadmin/Dockerfile
@@ -1,6 +1,0 @@
-FROM nsqio/deprecated_nsq_base:latest
-
-RUN cd /gopath/src/github.com/bitly/nsq/nsqadmin && go build .
-EXPOSE 4171
-
-ENTRYPOINT ["/gopath/src/github.com/bitly/nsq/nsqadmin/nsqadmin"]


### PR DESCRIPTION
Now we're trying to build the smallest container possible, and only ship
one container, instead of one container per app.

The strategy is to create a `docker` target in `dist`, and add all the
binaries from the linux target to that folder. The Dockerfile is based
off of `scratch`, and adds the `docker` target in `dist` at the root of
the filesystem. Finally, we add a `ca-certificates.crt` file (pulled
from CoreOS) so that SSL will continue to work.

This gives us a Docker image with about 5MB of overhead over the
binaries, compared to our previous strategy's ~700MB. It also means that
the versions will be easier to maintain and control.

The resulting images can be used as follows:

`docker run nsqio/nsq /nsqd --version`

Where `nsqd` is the binary you want to run. Unfortunately, I believe `/`
is required.

This is the result of our discussion in #528.