### PR TITLE
nsqd: orphaned ephemeral channels

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -413,6 +413,11 @@ func (n *NSQD) GetTopic(topicName string) *Topic {
 		if len(n.lookupPeers) > 0 {
 			channelNames, _ := lookupd.GetLookupdTopicChannels(t.name, n.lookupHttpAddrs())
 			for _, channelName := range channelNames {
+				if strings.HasSuffix(channelName, "#ephemeral") {
+					// we don't want to pre-create ephemeral channels
+					// because there isn't a client connected
+					continue
+				}
 				t.getOrCreateChannel(channelName)
 			}
 		}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -303,6 +303,9 @@ func (n *NSQD) PersistMetadata() error {
 	js := make(map[string]interface{})
 	topics := make([]interface{}, 0)
 	for _, topic := range n.topicMap {
+		if topic.ephemeral {
+			continue
+		}
 		topicData := make(map[string]interface{})
 		topicData["name"] = topic.name
 		topicData["paused"] = topic.IsPaused()
@@ -310,12 +313,14 @@ func (n *NSQD) PersistMetadata() error {
 		topic.Lock()
 		for _, channel := range topic.channelMap {
 			channel.Lock()
-			if !channel.ephemeral {
-				channelData := make(map[string]interface{})
-				channelData["name"] = channel.name
-				channelData["paused"] = channel.IsPaused()
-				channels = append(channels, channelData)
+			if channel.ephemeral {
+				channel.Unlock()
+				continue
 			}
+			channelData := make(map[string]interface{})
+			channelData["name"] = channel.name
+			channelData["paused"] = channel.IsPaused()
+			channels = append(channels, channelData)
 			channel.Unlock()
 		}
 		topic.Unlock()


### PR DESCRIPTION
If an `nsqd` cleanly exits while there are ephemeral channels with clients connected it will persist the existence of those channels to its metadata file on disk.

Upon startup, it will re-create those ephemeral channels.

If the names used for the ephemeral channels are random and not re-used upon client reconnection they are now effectively orphaned and will never be reconnected to and thus never cleaned up (something handled explicitly by disconnection of the last client).

Proposed fix is to not persist ephemeral topics and channels in the metadata file.

cc @jehiah @adamsathailo 