### PR TITLE
Set apps to use deprecated base Docker image.

### DIFF
--- a/apps/nsqd/Dockerfile
+++ b/apps/nsqd/Dockerfile
@@ -1,4 +1,4 @@
-FROM nsqio/nsq:latest
+FROM nsqio/deprecated_nsq_base:latest
 
 RUN cd /gopath/src/github.com/bitly/nsq/apps/nsqd && go build .
 VOLUME ["/data"]

--- a/apps/nsqlookupd/Dockerfile
+++ b/apps/nsqlookupd/Dockerfile
@@ -1,4 +1,4 @@
-FROM nsqio/nsq:latest
+FROM nsqio/deprecated_nsq_base:latest
 
 RUN cd /gopath/src/github.com/bitly/nsq/apps/nsqlookupd && go build .
 EXPOSE 4160

--- a/nsqadmin/Dockerfile
+++ b/nsqadmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM nsqio/nsq:latest
+FROM nsqio/deprecated_nsq_base:latest
 
 RUN cd /gopath/src/github.com/bitly/nsq/nsqadmin && go build .
 EXPOSE 4171


### PR DESCRIPTION
In the pursuit of taking another swing at the NSQ Docker strategy, we're
redoing the nsqio/nsq image. Trying to keep the app builds working,
however, required us to create a deprecated_nsq_base image that they
could use as a source layer.