### PR TITLE
nsq_to_http: accept any 2xx response

### DIFF
--- a/apps/nsq_to_http/nsq_to_http.go
+++ b/apps/nsq_to_http/nsq_to_http.go
@@ -134,7 +134,7 @@ func (p *PostPublisher) Publish(addr string, msg []byte) error {
 		return err
 	}
 	resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return errors.New(fmt.Sprintf("got status code %d", resp.StatusCode))
 	}
 	return nil


### PR DESCRIPTION
previously, nsq_to_http would fail on a 201, which is the response one receives when posting to elasticsearch. 