### PR TITLE
Enable shell expansion.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM scratch
+FROM busybox
 
 ADD dist/docker/bin/ /
+
+EXPOSE 4150 4151 4160 4161 4170 4171
 
 VOLUME /data
 VOLUME /etc/ssl/certs

--- a/dist.sh
+++ b/dist.sh
@@ -49,3 +49,8 @@ for os in linux darwin; do
 done
 
 docker build -t nsqio/nsq:v$version .
+if [[ ! $version == *"-"* ]]
+then
+	echo "Tagging nsqio/nsq:v${version} as the latest release.";
+	docker tag -f nsqio/nsq:v$version nsqio/nsq:latest
+fi


### PR DESCRIPTION
We're changing from scratch to busybox as a base image, after discussion
in #543. This gives us some free shell expansion.

I also added a step at the end of dist.sh that would take care of
tagging the image as the "latest" build, as long as there's not a hyphen
in the version number (so our "latest" build will never be an alpha or
beta, as I assume we want stability by default).

I also listed the ports used in the Dockerfile, so we can take advantage
of container linking.