### PR TITLE
Issue 533 -Adding start time to nsqd

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -40,6 +40,7 @@ type NSQD struct {
 	healthMtx sync.RWMutex
 	healthy   int32
 	err       error
+	startTime time.Time
 
 	topicMap map[string]*Topic
 
@@ -63,6 +64,7 @@ func NewNSQD(opts *nsqdOptions) *NSQD {
 	n := &NSQD{
 		opts:       opts,
 		healthy:    1,
+		startTime:  time.Now(),
 		topicMap:   make(map[string]*Topic),
 		idChan:     make(chan MessageID, 4096),
 		exitChan:   make(chan int),
@@ -168,6 +170,10 @@ func (n *NSQD) GetHealth() string {
 		return fmt.Sprintf("NOK - %s", n.GetError())
 	}
 	return "OK"
+}
+
+func (n *NSQD) GetStartTime() time.Time {
+	return n.startTime
 }
 
 func (n *NSQD) Main() {


### PR DESCRIPTION
Ready for reveiw

Adding a timestamp for start date to the json format and a readable start time and uptime to the text format for the stats endpoint

Sample text format: 
```
nsqd v0.3.3-alpha (built w/go1.4)
start_time 2015-02-21T20:25:51-08:00
uptime 1m18.478010195s

NO_TOPICS
```
Sample JSON:
```
 {"status_code":200,"status_txt":"OK","data":{"version":"0.3.3-alpha","health":"OK","start_time":1424579151,"topics":[]}}
```