### PR TITLE
exhaust request body

### DIFF
--- a/apps/nsq_to_http/nsq_to_http.go
+++ b/apps/nsq_to_http/nsq_to_http.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/url"
@@ -133,7 +135,9 @@ func (p *PostPublisher) Publish(addr string, msg []byte) error {
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return errors.New(fmt.Sprintf("got status code %d", resp.StatusCode))
 	}
@@ -148,7 +152,9 @@ func (p *GetPublisher) Publish(addr string, msg []byte) error {
 	if err != nil {
 		return err
 	}
+	io.Copy(ioutil.Discard, resp.Body)
 	resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		return errors.New(fmt.Sprintf("got status code %d", resp.StatusCode))
 	}


### PR DESCRIPTION
Hi, we're using nsq_to_http as a source for dark traffic testing--it's great!

Would you guys be open to consuming the request body? It adds the overhead of the round trips incurred by body bytes, but otherwise causes all types of transport errors on the other side should the endpoint expect to return a body.

This doesn't change functionality at all (I think.)