### PR TITLE
test.sh: fix find flag -depth to -maxdepth

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ go test -timeout 60s ./...
 GOMAXPROCS=4 go test -timeout 60s -race ./...
 
 # no tests, but a build is something
-for dir in $(find apps bench -depth 1 -type d) nsqadmin; do
+for dir in $(find apps bench -maxdepth 1 -type d) nsqadmin; do
     if grep -q '^package main$' $dir/*.go ; then
         echo "building $dir"
         go build -o $dir/$(basename $dir) ./$dir


### PR DESCRIPTION
-depth specifies depth first search for processing directories.
-maxdepth specifies how deep in directories to go.