### PR TITLE
nsqd: fix -tls-required=tcp-https with -tls-client-auth-policy

### DIFF
--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -118,7 +118,7 @@ func NewNSQD(opts *nsqdOptions) *NSQD {
 		opts.StatsdPrefix = prefixWithHost
 	}
 
-	if opts.TLSClientAuthPolicy != "" {
+	if opts.TLSClientAuthPolicy != "" && opts.TLSRequired == TLSNotRequired {
 		opts.TLSRequired = TLSRequired
 	}
 


### PR DESCRIPTION
Previously, specifying -tls-client-auth-policy would set -tls-required to
TLSRequired, overriding TLSRequiredExceptHTTP if it was specified.

Now, specifying the policy only sets TLSRequired if the current option is
TLSNotRequired.