### PR TITLE
nsqd: do not print EOF when closing cleanly

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -62,7 +62,11 @@ func (p *protocolV2) IOLoop(conn net.Conn) error {
 		// ie. the returned slice is only valid until the next call to it
 		line, err = client.Reader.ReadSlice('\n')
 		if err != nil {
-			err = fmt.Errorf("failed to read command - %s", err)
+			if atomic.LoadInt32(&client.State) == stateClosing {
+				err = nil
+			} else {
+				err = fmt.Errorf("failed to read command - %s", err)
+			}
 			break
 		}
 


### PR DESCRIPTION
When nsqd shuts down, protocol_v2 responds to CLS with CLOSE_WAIT and then the
IOLoop waits for another command with ReadSlice on the buffered client
connection. ReadSlice returns EOF because the client closes the connection;
this error is returned from IOLoop to the tcp handler and printed.

Because the presence of EOF is expected when the client is in stateClosing, the
error should be ignored.