### PR TITLE
build: go get fails due to "snappy"

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,10 +1,9 @@
-code.google.com/p/snappy-go/snappy      12e4b4183793ac4b061921e7980845e750679fd0
 github.com/BurntSushi/toml              2dff11163ee667d51dcc066660925a92ce138deb
 github.com/bitly/go-hostpool            58b95b10d6ca26723a7f46017b348653b825a8d6
 github.com/bitly/go-nsq                 5a2abdba46a853a75ccdeeead30ad34eabc4d72a # v1.0.3
 github.com/bitly/go-simplejson          fc395a5db941cf38922b1ccbc083640cd76fe4bc # v0.5.0-alpha
 github.com/bmizerany/perks/quantile     6cb9d9d729303ee2628580d9aec5db968da3a607
 github.com/mreiferson/go-options        2cf7eb1fdd83e2bb3375fef6fdadb04c3ad564da
-github.com/mreiferson/go-snappystream   307a466b220aaf34bcee2d19c605ed9e96b4bcdb # v0.2.0
+github.com/mreiferson/go-snappystream   028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504 # v0.2.3
 github.com/bitly/timer_metrics          afad1794bb13e2a094720aeb27c088aa64564895
 github.com/blang/semver                 9bf7bff48b0388cb75991e58c6df7d13e982f1f2


### PR DESCRIPTION
when I run go get github.com/bitly/go-nsq,it fails with the following:
package code.google.com/p/snappy-go/snappy: Get https://code.google.com/p/snappy-go/source/checkout?repo=: dial tcp 216.58.221.46:443: i/o timeout

