### PR TITLE
nsqd: skip persist metadata while loading

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -296,12 +296,7 @@ func (c *Channel) doPause(pause bool) error {
 		}
 	}
 	c.RUnlock()
-
-	c.ctx.nsqd.Lock()
-	defer c.ctx.nsqd.Unlock()
-	// pro-actively persist metadata so in case of process failure
-	// nsqd won't suddenly (un)pause a channel
-	return c.ctx.nsqd.PersistMetadata()
+	return nil
 }
 
 func (c *Channel) IsPaused() bool {

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -415,6 +415,11 @@ func (s *httpServer) doPauseTopic(req *http.Request) (interface{}, error) {
 		return nil, http_api.Err{500, "INTERNAL_ERROR"}
 	}
 
+	// pro-actively persist metadata so in case of process failure
+	// nsqd won't suddenly (un)pause a topic
+	s.ctx.nsqd.Lock()
+	s.ctx.nsqd.PersistMetadata()
+	s.ctx.nsqd.Unlock()
 	return nil, nil
 }
 
@@ -481,6 +486,11 @@ func (s *httpServer) doPauseChannel(req *http.Request) (interface{}, error) {
 		return nil, http_api.Err{500, "INTERNAL_ERROR"}
 	}
 
+	// pro-actively persist metadata so in case of process failure
+	// nsqd won't suddenly (un)pause a channel
+	s.ctx.nsqd.Lock()
+	s.ctx.nsqd.PersistMetadata()
+	s.ctx.nsqd.Unlock()
 	return nil, nil
 }
 

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -413,11 +413,6 @@ func (t *Topic) doPause(pause bool) error {
 
 	select {
 	case t.pauseChan <- pause:
-		t.ctx.nsqd.Lock()
-		defer t.ctx.nsqd.Unlock()
-		// pro-actively persist metadata so in case of process failure
-		// nsqd won't suddenly (un)pause a topic
-		return t.ctx.nsqd.PersistMetadata()
 	case <-t.exitChan:
 	}
 


### PR DESCRIPTION
:laughing: :laughing: :laughing: 
reasons:
1. the in-memory metadata is incomplete;
2. nsqd triggers N (where N >= # of topics + channels)
    times `PersistMetadata` call which is unnecessary;
3. nsqd will persist metadata after loading.