### PR TITLE
nsqd: questions for large number of topics/channels

### DIFF
--- a/internal/util/rand.go
+++ b/internal/util/rand.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"math/rand"
+)
+
+func UniqRands(l int, n int) []int {
+	set := make(map[int]struct{})
+	nums := make([]int, 0, l)
+	for {
+		num := rand.Intn(n)
+		if _, ok := set[num]; !ok {
+			set[num] = struct{}{}
+			nums = append(nums, num)
+		}
+		if len(nums) == l {
+			goto exit
+		}
+	}
+exit:
+	return nums
+}

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -219,7 +219,7 @@ func (c *Channel) flush() error {
 	var msgBuf bytes.Buffer
 
 	// messagePump is responsible for closing the channel it writes to
-	// this will read until its closed (exited)
+	// this will read until it's closed (exited)
 	for msg := range c.clientMsgChan {
 		c.ctx.nsqd.logf("CHANNEL(%s): recovered buffered message from clientMsgChan", c.name)
 		writeMessageToBackend(&msgBuf, msg, c.backend)
@@ -537,11 +537,8 @@ func (c *Channel) addToDeferredPQ(item *pqueue.Item) {
 	heap.Push(&c.deferredPQ, item)
 }
 
-// messagePump reads messages from either memory or backend and writes
-// to the client output go channel
-//
-// it is also performs in-flight accounting and initiates the auto-requeue
-// goroutine
+// messagePump reads messages from either memory or backend and sends
+// messages to clients over a go chan
 func (c *Channel) messagePump() {
 	var msg *Message
 	var buf []byte

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -12,11 +12,7 @@ import (
 
 	"github.com/bitly/nsq/internal/pqueue"
 	"github.com/bitly/nsq/internal/quantile"
-	"github.com/bitly/nsq/internal/util"
 )
-
-// the amount of time a worker will wait when idle
-const defaultWorkerWait = 100 * time.Millisecond
 
 type Consumer interface {
 	UnPause()
@@ -52,8 +48,8 @@ type Channel struct {
 	memoryMsgChan chan *Message
 	clientMsgChan chan *Message
 	exitChan      chan int
-	waitGroup     util.WaitGroupWrapper
 	exitFlag      int32
+	exitMutex     sync.RWMutex
 
 	// state tracking
 	clients        map[int64]Consumer
@@ -116,9 +112,6 @@ func NewChannel(topicName string, channelName string, ctx *context,
 
 	go c.messagePump()
 
-	c.waitGroup.Wrap(func() { c.deferredWorker() })
-	c.waitGroup.Wrap(func() { c.inFlightWorker() })
-
 	c.ctx.nsqd.Notify(c)
 
 	return c
@@ -155,6 +148,9 @@ func (c *Channel) Close() error {
 }
 
 func (c *Channel) exit(deleted bool) error {
+	c.exitMutex.Lock()
+	defer c.exitMutex.Unlock()
+
 	if !atomic.CompareAndSwapInt32(&c.exitFlag, 0, 1) {
 		return errors.New("exiting")
 	}
@@ -177,9 +173,6 @@ func (c *Channel) exit(deleted bool) error {
 	c.RUnlock()
 
 	close(c.exitChan)
-
-	// synchronize the close of router() and pqWorkers (2)
-	c.waitGroup.Wait()
 
 	if deleted {
 		// empty the queue (deletes the backend files, too)
@@ -587,80 +580,70 @@ exit:
 	close(c.clientMsgChan)
 }
 
-func (c *Channel) deferredWorker() {
-	c.pqWorker(&c.deferredPQ, &c.deferredMutex, func(item *pqueue.Item) {
+func (c *Channel) processDeferredQueue(t int64) bool {
+	c.exitMutex.RLock()
+	defer c.exitMutex.RUnlock()
+
+	if c.Exiting() {
+		return false
+	}
+
+	dirty := false
+	for {
+		c.deferredMutex.Lock()
+		item, _ := c.deferredPQ.PeekAndShift(t)
+		c.deferredMutex.Unlock()
+
+		if item == nil {
+			goto exit
+		}
+		dirty = true
+
 		msg := item.Value.(*Message)
 		_, err := c.popDeferredMessage(msg.ID)
 		if err != nil {
-			return
+			goto exit
 		}
 		c.doRequeue(msg)
-	})
-}
-
-func (c *Channel) inFlightWorker() {
-	ticker := time.NewTicker(defaultWorkerWait)
-	for {
-		select {
-		case <-ticker.C:
-		case <-c.exitChan:
-			goto exit
-		}
-		now := time.Now().UnixNano()
-		for {
-			c.inFlightMutex.Lock()
-			msg, _ := c.inFlightPQ.PeekAndShift(now)
-			c.inFlightMutex.Unlock()
-
-			if msg == nil {
-				break
-			}
-
-			_, err := c.popInFlightMessage(msg.clientID, msg.ID)
-			if err != nil {
-				break
-			}
-			atomic.AddUint64(&c.timeoutCount, 1)
-			c.RLock()
-			client, ok := c.clients[msg.clientID]
-			c.RUnlock()
-			if ok {
-				client.TimedOutMessage()
-			}
-			c.doRequeue(msg)
-		}
 	}
 
 exit:
-	c.ctx.nsqd.logf("CHANNEL(%s): closing ... inFlightWorker", c.name)
-	ticker.Stop()
+	return dirty
 }
 
-// generic loop (executed in a goroutine) that periodically wakes up to walk
-// the priority queue and call the callback
-func (c *Channel) pqWorker(pq *pqueue.PriorityQueue, mutex *sync.Mutex, callback func(item *pqueue.Item)) {
-	ticker := time.NewTicker(defaultWorkerWait)
+func (c *Channel) processInFlightQueue(t int64) bool {
+	c.exitMutex.RLock()
+	defer c.exitMutex.RUnlock()
+
+	if c.Exiting() {
+		return false
+	}
+
+	dirty := false
 	for {
-		select {
-		case <-ticker.C:
-		case <-c.exitChan:
+		c.inFlightMutex.Lock()
+		msg, _ := c.inFlightPQ.PeekAndShift(t)
+		c.inFlightMutex.Unlock()
+
+		if msg == nil {
 			goto exit
 		}
-		now := time.Now().UnixNano()
-		for {
-			mutex.Lock()
-			item, _ := pq.PeekAndShift(now)
-			mutex.Unlock()
+		dirty = true
 
-			if item == nil {
-				break
-			}
-
-			callback(item)
+		_, err := c.popInFlightMessage(msg.clientID, msg.ID)
+		if err != nil {
+			goto exit
 		}
+		atomic.AddUint64(&c.timeoutCount, 1)
+		c.RLock()
+		client, ok := c.clients[msg.clientID]
+		c.RUnlock()
+		if ok {
+			client.TimedOutMessage()
+		}
+		c.doRequeue(msg)
 	}
 
 exit:
-	c.ctx.nsqd.logf("CHANNEL(%s): closing ... pqueue worker", c.name)
-	ticker.Stop()
+	return dirty
 }

--- a/nsqd/channel_test.go
+++ b/nsqd/channel_test.go
@@ -60,6 +60,7 @@ func TestInFlightWorker(t *testing.T) {
 	opts := NewNSQDOptions()
 	opts.Logger = newTestLogger(t)
 	opts.MsgTimeout = 100 * time.Millisecond
+	opts.QueueScanRefreshInterval = 100 * time.Millisecond
 	_, _, nsqd := mustStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -28,6 +28,12 @@ type nsqdOptions struct {
 	SyncEvery       int64         `flag:"sync-every"`
 	SyncTimeout     time.Duration `flag:"sync-timeout"`
 
+	QueueScanInterval        time.Duration
+	QueueScanRefreshInterval time.Duration
+	QueueScanSelectionCount  int
+	QueueScanWorkerPoolMax   int
+	QueueScanDirtyPercent    float64
+
 	// msg and command options
 	MsgTimeout    time.Duration `flag:"msg-timeout" arg:"1ms"`
 	MaxMsgTimeout time.Duration `flag:"max-msg-timeout"`
@@ -84,6 +90,12 @@ func NewNSQDOptions() *nsqdOptions {
 		MaxBytesPerFile: 104857600,
 		SyncEvery:       2500,
 		SyncTimeout:     2 * time.Second,
+
+		QueueScanInterval:        100 * time.Millisecond,
+		QueueScanRefreshInterval: 5 * time.Second,
+		QueueScanSelectionCount:  20,
+		QueueScanWorkerPoolMax:   4,
+		QueueScanDirtyPercent:    0.25,
 
 		MsgTimeout:    60 * time.Second,
 		MaxMsgTimeout: 15 * time.Minute,

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -82,7 +82,7 @@ func sub(t *testing.T, conn io.ReadWriter, topicName string, channelName string)
 }
 
 func authCmd(t *testing.T, conn io.ReadWriter, authSecret string, expectSuccess string) {
-	auth := &nsq.Command{[]byte("AUTH"), nil, []byte(authSecret)}
+	auth, _ := nsq.Auth(authSecret)
 	_, err := auth.WriteTo(conn)
 	equal(t, err, nil)
 	if expectSuccess != "" {
@@ -1380,7 +1380,8 @@ func TestBadFin(t *testing.T) {
 	identify(t, conn, map[string]interface{}{}, frameTypeResponse)
 	sub(t, conn, "test_fin", "ch")
 
-	fin := &nsq.Command{[]byte("FIN"), [][]byte{[]byte("")}, nil}
+	fin := nsq.Finish(nsq.MessageID{})
+	fin.Params[0] = []byte("")
 	_, err = fin.WriteTo(conn)
 	equal(t, err, nil)
 

--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1317,6 +1317,7 @@ func TestClientMsgTimeout(t *testing.T) {
 	opts := NewNSQDOptions()
 	opts.Logger = newTestLogger(t)
 	opts.Verbose = true
+	opts.QueueScanRefreshInterval = 100 * time.Millisecond
 	tcpAddr, _, nsqd := mustStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()


### PR DESCRIPTION
Background: We need to dispatch user messages to a specific topic, where every consumer only subscribe the message for a fixed range of user. Since nsqd doesn't support partitions by key, we created thousands of topics/channels, i.e. user_topic_[0-999], one topic for a range of users.

Let's suppose there will be 10K topics and channels, we want to know that whether nsqd will work well or not in this situations.

1. file number limit of process. This is easy to increase it.
2. memory consumption? After some trying, seems not so much memory consumption.
3. High cpu usage even if EMPTY workload. About 40% - 60% for one nsqd process, while no producer or consumer connect to it. `strace` tells there are lots of futex syscall.
    @xiaost helps to troubleshoot, it may be caused by the 100ms ticker for every channel, and maybe we need to make it configurable?
4. slow startup. @xiaost already submited a PR https://github.com/bitly/nsq/pull/575
5. Any other potential problems?

Thanks 
    