### PR TITLE
nsqd: benchmark panics

### DIFF
--- a/nsqd/protocol_v2_test.go
+++ b/nsqd/protocol_v2_test.go
@@ -1400,7 +1400,7 @@ func benchmarkProtocolV2Pub(b *testing.B, size int) {
 	opts.MemQueueSize = int64(b.N)
 	tcpAddr, _, nsqd := mustStartNSQD(opts)
 	msg := make([]byte, size)
-	batchSize := 200
+	batchSize := int(opts.MaxBodySize) / size
 	batch := make([][]byte, batchSize)
 	for i := range batch {
 		batch[i] = msg


### PR DESCRIPTION
In particular, `BenchmarkProtocolV2Pub32k`:

```
$ go test -bench=ProtocolV2Pub32k -run=XXX                                                                                                                                                                                      !
PASS
BenchmarkProtocolV2Pub32k       panic: write tcp 127.0.0.1:55383: connection reset by peer

goroutine 26 [running]:
github.com/bitly/nsq/nsqd.func·051()
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:1427 +0x36e
created by github.com/bitly/nsq/nsqd.benchmarkProtocolV2Pub
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:1443 +0x68d

goroutine 1 [chan receive]:
testing.(*B).run(0xc208070400, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/caleb/apps/go/src/testing/benchmark.go:180 +0x67
testing.RunBenchmarks(0x9544a8, 0xaa0b80, 0x2a, 0x2a)
        /home/caleb/apps/go/src/testing/benchmark.go:312 +0x649
testing.(*M).Run(0xc20804e410, 0xaad140)
        /home/caleb/apps/go/src/testing/testing.go:494 +0x1a5
main.main()
        github.com/bitly/nsq/nsqd/_test/_testmain.go:264 +0x1d5

goroutine 22 [select]:
github.com/bitly/nsq/nsqd.(*NSQD).idPump(0xc208000ea0)
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/nsqd.go:497 +0x388
github.com/bitly/nsq/nsqd.func·030()
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/nsqd.go:132 +0x2a
github.com/bitly/nsq/util.func·003()
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:14 +0x2f
created by github.com/bitly/nsq/util.(*WaitGroupWrapper).Wrap
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:16 +0xf7

goroutine 6 [semacquire]:
sync.(*WaitGroup).Wait(0xc20801c000)
        /home/caleb/apps/go/src/sync/waitgroup.go:132 +0x169
github.com/bitly/nsq/nsqd.benchmarkProtocolV2Pub(0xc208070400, 0x8000)
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:1446 +0x6ec
github.com/bitly/nsq/nsqd.BenchmarkProtocolV2Pub32k(0xc208070400)
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/protocol_v2_test.go:1459 +0x31
testing.(*B).runN(0xc208070400, 0x2710)
        /home/caleb/apps/go/src/testing/benchmark.go:124 +0x95
testing.(*B).launch(0xc208070400)
        /home/caleb/apps/go/src/testing/benchmark.go:216 +0x159
created by testing.(*B).run
        /home/caleb/apps/go/src/testing/benchmark.go:179 +0x3e

goroutine 23 [select]:
github.com/bitly/nsq/nsqd.(*NSQD).lookupLoop(0xc208000ea0)
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/lookup.go:64 +0x3008
github.com/bitly/nsq/nsqd.func·031()
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/nsqd.go:185 +0x2a
github.com/bitly/nsq/util.func·003()
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:14 +0x2f
created by github.com/bitly/nsq/util.(*WaitGroupWrapper).Wrap
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:16 +0xf7

goroutine 25 [IO wait]:
net.(*pollDesc).Wait(0xc208012530, 0x72, 0x0, 0x0)
        /home/caleb/apps/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208012530, 0x0, 0x0)
        /home/caleb/apps/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc2080124d0, 0x0, 0x7fcbec61ec08, 0xc20808c828)
        /home/caleb/apps/go/src/net/fd_unix.go:419 +0x40b
net.(*TCPListener).AcceptTCP(0xc20804c0d8, 0xc20801e380, 0x0, 0x0)
        /home/caleb/apps/go/src/net/tcpsock_posix.go:234 +0x4e
net.(*TCPListener).Accept(0xc20804c0d8, 0x0, 0x0, 0x0, 0x0)
        /home/caleb/apps/go/src/net/tcpsock_posix.go:244 +0x4c
net/http.(*Server).Serve(0xc2080404e0, 0x7fcbec61f6c8, 0xc20804c0d8, 0x0, 0x0)
        /home/caleb/apps/go/src/net/http/server.go:1728 +0x92
github.com/bitly/nsq/util.HTTPServer(0x7fcbec61f6c8, 0xc20804c0d8, 0x7fcbec620800, 0xc20808c660, 0x7fcbec620760, 0xc20808c300, 0x86be30, 0x4)
        /home/caleb/p/go/src/github.com/bitly/nsq/util/http_server.go:16 +0x26b
github.com/bitly/nsq/nsqd.func·034()
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/nsqd.go:226 +0xf6
github.com/bitly/nsq/util.func·003()
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:14 +0x2f
created by github.com/bitly/nsq/util.(*WaitGroupWrapper).Wrap
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:16 +0xf7

goroutine 24 [IO wait]:
net.(*pollDesc).Wait(0xc208012450, 0x72, 0x0, 0x0)
        /home/caleb/apps/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208012450, 0x0, 0x0)
        /home/caleb/apps/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc2080123f0, 0x0, 0x7fcbec61ec08, 0xc20808d238)
        /home/caleb/apps/go/src/net/fd_unix.go:419 +0x40b
net.(*TCPListener).AcceptTCP(0xc20804c0a0, 0xc208017668, 0x0, 0x0)
        /home/caleb/apps/go/src/net/tcpsock_posix.go:234 +0x4e
net.(*TCPListener).Accept(0xc20804c0a0, 0x0, 0x0, 0x0, 0x0)
        /home/caleb/apps/go/src/net/tcpsock_posix.go:244 +0x4c
github.com/bitly/nsq/util.TCPServer(0x7fcbec61f6c8, 0xc20804c0a0, 0x7fcbec620738, 0xc20804c0b8, 0x7fcbec620760, 0xc20808c300)
        /home/caleb/p/go/src/github.com/bitly/nsq/util/tcp_server.go:18 +0x184
github.com/bitly/nsq/nsqd.func·032()
        /home/caleb/p/go/src/github.com/bitly/nsq/nsqd/nsqd.go:195 +0xe0
github.com/bitly/nsq/util.func·003()
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:14 +0x2f
created by github.com/bitly/nsq/util.(*WaitGroupWrapper).Wrap
        /home/caleb/p/go/src/github.com/bitly/nsq/util/wait_group_wrapper.go:16 +0xf7
exit status 2
FAIL    github.com/bitly/nsq/nsqd       0.023s
```