### PR TITLE
nsqd: support deferred PUB

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,6 +1,6 @@
 github.com/BurntSushi/toml              2dff11163ee667d51dcc066660925a92ce138deb
 github.com/bitly/go-hostpool            58b95b10d6ca26723a7f46017b348653b825a8d6
-github.com/bitly/go-nsq                 22a8bd48c443ec23bb559675b6df8284bbbdab29 # v1.0.4
+github.com/bitly/go-nsq                 4271cd1529a78175e327570894988cc2cb21228f # v1.0.5-alpha
 github.com/bitly/go-simplejson          fc395a5db941cf38922b1ccbc083640cd76fe4bc # v0.5.0-alpha
 github.com/bmizerany/perks/quantile     6cb9d9d729303ee2628580d9aec5db968da3a607
 github.com/mreiferson/go-options        2cf7eb1fdd83e2bb3375fef6fdadb04c3ad564da

--- a/nsqd/http_test.go
+++ b/nsqd/http_test.go
@@ -154,6 +154,33 @@ func TestHTTPmputBinary(t *testing.T) {
 	equal(t, topic.Depth(), int64(5))
 }
 
+func TestHTTPpubDefer(t *testing.T) {
+	opts := NewNSQDOptions()
+	opts.Logger = newTestLogger(t)
+	_, httpAddr, nsqd := mustStartNSQD(opts)
+	defer os.RemoveAll(opts.DataPath)
+	defer nsqd.Exit()
+
+	topicName := "test_http_pub_defer" + strconv.Itoa(int(time.Now().Unix()))
+	topic := nsqd.GetTopic(topicName)
+	ch := topic.GetChannel("ch")
+
+	buf := bytes.NewBuffer([]byte("test message"))
+	url := fmt.Sprintf("http://%s/pub?topic=%s&defer=%d", httpAddr, topicName, 1000)
+	resp, err := http.Post(url, "application/octet-stream", buf)
+	equal(t, err, nil)
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+	equal(t, string(body), "OK")
+
+	time.Sleep(5 * time.Millisecond)
+
+	ch.Lock()
+	numDef := len(ch.deferredMessages)
+	ch.Unlock()
+	equal(t, numDef, 1)
+}
+
 func TestHTTPSRequire(t *testing.T) {
 	opts := NewNSQDOptions()
 	opts.Logger = newTestLogger(t)

--- a/nsqd/message.go
+++ b/nsqd/message.go
@@ -24,6 +24,7 @@ type Message struct {
 	clientID   int64
 	pri        int64
 	index      int
+	deferred   time.Duration
 }
 
 func NewMessage(id MessageID, body []byte) *Message {

--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -185,6 +185,8 @@ func (p *protocolV2) Exec(client *clientV2, params [][]byte) ([]byte, error) {
 		return p.PUB(client, params)
 	case bytes.Equal(params[0], []byte("MPUB")):
 		return p.MPUB(client, params)
+	case bytes.Equal(params[0], []byte("DPUB")):
+		return p.DPUB(client, params)
 	case bytes.Equal(params[0], []byte("NOP")):
 		return p.NOP(client, params)
 	case bytes.Equal(params[0], []byte("TOUCH")):
@@ -812,6 +814,68 @@ func (p *protocolV2) MPUB(client *clientV2, params [][]byte) ([]byte, error) {
 	err = topic.PutMessages(messages)
 	if err != nil {
 		return nil, protocol.NewFatalClientErr(err, "E_MPUB_FAILED", "MPUB failed "+err.Error())
+	}
+
+	return okBytes, nil
+}
+
+func (p *protocolV2) DPUB(client *clientV2, params [][]byte) ([]byte, error) {
+	var err error
+
+	if len(params) < 3 {
+		return nil, protocol.NewFatalClientErr(nil, "E_INVALID", "DPUB insufficient number of parameters")
+	}
+
+	topicName := string(params[1])
+	if !protocol.IsValidTopicName(topicName) {
+		return nil, protocol.NewFatalClientErr(nil, "E_BAD_TOPIC",
+			fmt.Sprintf("DPUB topic name %q is not valid", topicName))
+	}
+
+	timeoutMs, err := protocol.ByteToBase10(params[2])
+	if err != nil {
+		return nil, protocol.NewFatalClientErr(err, "E_INVALID",
+			fmt.Sprintf("DPUB could not parse timeout %s", params[2]))
+	}
+	timeoutDuration := time.Duration(timeoutMs) * time.Millisecond
+
+	if timeoutDuration < 0 || timeoutDuration > p.ctx.nsqd.opts.MaxReqTimeout {
+		return nil, protocol.NewFatalClientErr(nil, "E_INVALID",
+			fmt.Sprintf("DPUB timeout %d out of range 0-%d",
+				timeoutMs, p.ctx.nsqd.opts.MaxReqTimeout/time.Millisecond))
+	}
+
+	bodyLen, err := readLen(client.Reader, client.lenSlice)
+	if err != nil {
+		return nil, protocol.NewFatalClientErr(err, "E_BAD_MESSAGE", "DPUB failed to read message body size")
+	}
+
+	if bodyLen <= 0 {
+		return nil, protocol.NewFatalClientErr(nil, "E_BAD_MESSAGE",
+			fmt.Sprintf("DPUB invalid message body size %d", bodyLen))
+	}
+
+	if int64(bodyLen) > p.ctx.nsqd.opts.MaxMsgSize {
+		return nil, protocol.NewFatalClientErr(nil, "E_BAD_MESSAGE",
+			fmt.Sprintf("DPUB message too big %d > %d", bodyLen, p.ctx.nsqd.opts.MaxMsgSize))
+	}
+
+	messageBody := make([]byte, bodyLen)
+	_, err = io.ReadFull(client.Reader, messageBody)
+	if err != nil {
+		return nil, protocol.NewFatalClientErr(err, "E_BAD_MESSAGE", "DPUB failed to read message body")
+	}
+
+	if err := p.CheckAuth(client, "DPUB", topicName, ""); err != nil {
+		return nil, err
+	}
+
+	topic := p.ctx.nsqd.GetTopic(topicName)
+	msg := NewMessage(<-p.ctx.nsqd.idChan, messageBody)
+	msg.deferred = timeoutDuration
+	err = topic.PutMessage(msg)
+	if err != nil {
+		return nil, protocol.NewFatalClientErr(err, "E_DPUB_FAILED", "DPUB failed "+err.Error())
 	}
 
 	return okBytes, nil

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -270,6 +270,11 @@ func (t *Topic) messagePump() {
 			if i > 0 {
 				chanMsg = NewMessage(msg.ID, msg.Body)
 				chanMsg.Timestamp = msg.Timestamp
+				chanMsg.deferred = msg.deferred
+			}
+			if chanMsg.deferred != 0 {
+				channel.StartDeferredTimeout(chanMsg, chanMsg.deferred)
+				continue
 			}
 			err := channel.PutMessage(chanMsg)
 			if err != nil {


### PR DESCRIPTION
This came up on the mailing list: https://groups.google.com/forum/#!topic/nsq-users/HkoOMygaHK0 - just opening the issue here for others to weigh in and gauge interest.

This would allow you to `PUB` a message that goes directly to the deferred priority queue with the specified delay.

Also, It's complicated a bit by #34.