### PR TITLE
nsqd: io.EOF when client-conn is closed

### DIFF
--- a/nsqd/protocol_v2.go
+++ b/nsqd/protocol_v2.go
@@ -62,7 +62,7 @@ func (p *protocolV2) IOLoop(conn net.Conn) error {
 		// ie. the returned slice is only valid until the next call to it
 		line, err = client.Reader.ReadSlice('\n')
 		if err != nil {
-			if atomic.LoadInt32(&client.State) == stateClosing {
+			if err == io.EOF {
 				err = nil
 			} else {
 				err = fmt.Errorf("failed to read command - %s", err)


### PR DESCRIPTION
NSQd does not distinguish io.EOF.
nsq/nsqd/protocol_v2.go

```Golang
        line, err = client.Reader.ReadSlice('\n')
        if err != nil {
            if atomic.LoadInt32(&client.State) == stateClosing {
                err = nil 
            } else {
                err = fmt.Errorf("failed to read command - %s", err)
            }   
            break
        }
```