### PR TITLE
docker: root directory is /dist/docker/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM busybox
 
-ADD dist/docker/bin/ /
+ADD dist/docker/bin/ /nsq_bin/
+RUN cd /    && ln -s /nsq_bin/* . \
+ && cd /bin && ln -s /nsq_bin/* .
 
 EXPOSE 4150 4151 4160 4161 4170 4171
 

--- a/dist.sh
+++ b/dist.sh
@@ -18,10 +18,14 @@ set -e
 # build binary distributions for linux/amd64 and darwin/amd64
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkdir -p $DIR/dist
-rm -rf $DIR/dist/docker
+if [ -e $DIR/dist/docker ]; then
+    rm -rf $DIR/dist/docker
+fi
 mkdir -p $DIR/dist/docker
 
+if [ -e $DIR/.godeps ]; then
+    rm -rf $DIR/.godeps
+fi
 mkdir -p $DIR/.godeps
 export GOPATH=$DIR/.godeps:$GOPATH
 GOPATH=$DIR/.godeps gpm install


### PR DESCRIPTION
Is there a reason that / is set to /dist/docker/bin for the docker image?

I would like to use nsq_to_file and output messages to /dev/null to avoid the queues filling up my server disks while testing, which is not possible because of this.