### PR TITLE
docs: --e2e-processing-latency-percentile format unclear

### DIFF
--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -123,7 +123,7 @@ func nsqFlagset() *flag.FlagSet {
 
 	// End to end percentile flags
 	e2eProcessingLatencyPercentiles := app.FloatArray{}
-	flagSet.Var(&e2eProcessingLatencyPercentiles, "e2e-processing-latency-percentile", "message processing time percentiles to keep track of (can be specified multiple times or comma separated, default none)")
+	flagSet.Var(&e2eProcessingLatencyPercentiles, "e2e-processing-latency-percentile", "message processing time percentiles (as float (0, 1.0]) to track (can be specified multiple times or comma separated '1.0,0.99,0.95', default none)")
 	flagSet.Duration("e2e-processing-latency-window-time", 10*time.Minute, "calculate end to end latency quantiles for this duration of time (ie: 60s would only show quantile calculations from the past 60 seconds)")
 
 	// TLS config


### PR DESCRIPTION
what's the right way to specify this option?
like `-e2e-processing-latency-percentile=90,99` ? or `.90,.99` since some of the code suggests it should be a float?