### PR TITLE
nsqadmin: doesn't handle nsqd --tls-required flag

### DIFF
--- a/apps/nsq_stat/nsq_stat.go
+++ b/apps/nsq_stat/nsq_stat.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bitly/nsq/internal/app"
 	"github.com/bitly/nsq/internal/clusterinfo"
+	"github.com/bitly/nsq/internal/http_api"
 	"github.com/bitly/nsq/internal/version"
 )
 
@@ -56,7 +57,7 @@ func init() {
 
 func statLoop(interval time.Duration, topic string, channel string,
 	nsqdTCPAddrs []string, lookupdHTTPAddrs []string) {
-	ci := clusterinfo.New(nil)
+	ci := clusterinfo.New(nil, http_api.NewClient(nil))
 	var o *clusterinfo.ChannelStats
 	for i := 0; !countNum.isSet || countNum.value >= i; i++ {
 		var producerList clusterinfo.ProducerList

--- a/apps/nsq_to_file/nsq_to_file.go
+++ b/apps/nsq_to_file/nsq_to_file.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bitly/go-nsq"
 	"github.com/bitly/nsq/internal/app"
 	"github.com/bitly/nsq/internal/clusterinfo"
+	"github.com/bitly/nsq/internal/http_api"
 	"github.com/bitly/nsq/internal/version"
 )
 
@@ -403,7 +404,7 @@ func (t *TopicDiscoverer) allowTopicName(pattern string, name string) bool {
 }
 
 func (t *TopicDiscoverer) syncTopics(addrs []string, pattern string) {
-	newTopics, err := clusterinfo.New(nil).GetLookupdTopics(addrs)
+	newTopics, err := clusterinfo.New(nil, http_api.NewClient(nil)).GetLookupdTopics(addrs)
 	if err != nil {
 		log.Printf("ERROR: could not retrieve topic list: %s", err)
 	}
@@ -514,7 +515,7 @@ func main() {
 		}
 		topicsFromNSQLookupd = true
 		var err error
-		topics, err = clusterinfo.New(nil).GetLookupdTopics(lookupdHTTPAddrs)
+		topics, err = clusterinfo.New(nil, http_api.NewClient(nil)).GetLookupdTopics(lookupdHTTPAddrs)
 		if err != nil {
 			log.Fatalf("ERROR: could not retrieve topic list: %s", err)
 		}

--- a/apps/nsqadmin/main.go
+++ b/apps/nsqadmin/main.go
@@ -34,6 +34,11 @@ var (
 
 	notificationHTTPEndpoint = flagSet.String("notification-http-endpoint", "", "HTTP endpoint (fully qualified) to which POST notifications of admin actions will be sent")
 
+	httpClientTLSInsecureSkipVerify = flagSet.Bool("http-client-tls-insecure-skip-verify", false, "configure the HTTP client to skip verification of TLS certificates")
+	httpClientTLSRootCAFile         = flagSet.String("http-client-tls-root-ca-file", "", "path to CA file for the HTTP client")
+	httpClientTLSCert               = flagSet.String("http-client-tls-cert", "", "path to certificate file for the HTTP client")
+	httpClientTLSKey                = flagSet.String("http-client-tls-key", "", "path to key file for the HTTP client")
+
 	nsqlookupdHTTPAddresses = app.StringArray{}
 	nsqdHTTPAddresses       = app.StringArray{}
 )

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -128,9 +128,9 @@ func nsqFlagset() *flag.FlagSet {
 
 	// TLS config
 	flagSet.String("tls-cert", "", "path to certificate file")
-	flagSet.String("tls-key", "", "path to private key file")
+	flagSet.String("tls-key", "", "path to key file")
 	flagSet.String("tls-client-auth-policy", "", "client certificate auth policy ('require' or 'require-verify')")
-	flagSet.String("tls-root-ca-file", "", "path to private certificate authority pem")
+	flagSet.String("tls-root-ca-file", "", "path to certificate authority file")
 	var tlsRequired tlsRequiredOption
 	var tlsMinVersion tlsVersionOption
 	flagSet.Var(&tlsRequired, "tls-required", "require TLS for client connections (true, false, tcp-https)")
@@ -175,7 +175,6 @@ func (cfg config) Validate() {
 }
 
 func main() {
-
 	flagSet := nsqFlagset()
 	flagSet.Parse(os.Args[1:])
 

--- a/internal/auth/authorizations.go
+++ b/internal/auth/authorizations.go
@@ -97,7 +97,8 @@ func QueryAuthd(authd, remoteIP, tlsEnabled, authSecret string) (*State, error) 
 	endpoint := fmt.Sprintf("http://%s/auth?%s", authd, v.Encode())
 
 	var authState State
-	if err := http_api.GETV1(endpoint, &authState); err != nil {
+	client := http_api.NewClient(nil)
+	if err := client.GETV1(endpoint, &authState); err != nil {
 		return nil, err
 	}
 

--- a/internal/clusterinfo/data.go
+++ b/internal/clusterinfo/data.go
@@ -17,11 +17,15 @@ type logger interface {
 }
 
 type ClusterInfo struct {
-	log logger
+	log    logger
+	client *http_api.Client
 }
 
-func New(log logger) *ClusterInfo {
-	return &ClusterInfo{log}
+func New(log logger, client *http_api.Client) *ClusterInfo {
+	return &ClusterInfo{
+		log:    log,
+		client: client,
+	}
 }
 
 func (c *ClusterInfo) logf(f string, args ...interface{}) {
@@ -38,7 +42,7 @@ func (c *ClusterInfo) GetVersion(addr string) (semver.Version, error) {
 	var resp struct {
 		Version string `json:'version'`
 	}
-	err := http_api.NegotiateV1(endpoint, &resp)
+	err := c.client.NegotiateV1(endpoint, &resp)
 	if err != nil {
 		c.logf("ERROR: %s - %s", endpoint, err)
 		return semver.Version{}, err
@@ -69,7 +73,7 @@ func (c *ClusterInfo) GetLookupdTopics(lookupdHTTPAddrs []string) ([]string, err
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			if err != nil {
 				c.logf("ERROR: lookupd %s - %s", endpoint, err)
 				return
@@ -112,7 +116,7 @@ func (c *ClusterInfo) GetLookupdTopicChannels(topic string, lookupdHTTPAddrs []s
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			lock.Lock()
 			defer lock.Unlock()
 			if err != nil {
@@ -156,7 +160,7 @@ func (c *ClusterInfo) GetLookupdProducers(lookupdHTTPAddrs []string) (ProducerLi
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			if err != nil {
 				c.logf("ERROR: lookupd %s - %s", endpoint, err)
 				return
@@ -216,7 +220,7 @@ func (c *ClusterInfo) GetLookupdTopicProducers(topic string, lookupdHTTPAddrs []
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			if err != nil {
 				c.logf("ERROR: lookupd %s - %s", endpoint, err)
 				return
@@ -257,7 +261,7 @@ func (c *ClusterInfo) GetNSQDTopics(nsqdHTTPAddrs []string) ([]string, error) {
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			if err != nil {
 				c.logf("ERROR: lookupd %s - %s", endpoint, err)
 				return
@@ -312,7 +316,7 @@ func (c *ClusterInfo) GetNSQDProducers(nsqdHTTPAddrs []string) (ProducerList, er
 			c.logf("NSQD: querying %s", endpoint)
 
 			var infoResp infoRespType
-			err := http_api.NegotiateV1(endpoint, &infoResp)
+			err := c.client.NegotiateV1(endpoint, &infoResp)
 			if err != nil {
 				c.logf("ERROR: nsqd %s - %s", endpoint, err)
 				return
@@ -322,7 +326,7 @@ func (c *ClusterInfo) GetNSQDProducers(nsqdHTTPAddrs []string) (ProducerList, er
 			c.logf("NSQD: querying %s", endpoint)
 
 			var statsResp statsRespType
-			err = http_api.NegotiateV1(endpoint, &statsResp)
+			err = c.client.NegotiateV1(endpoint, &statsResp)
 			if err != nil {
 				c.logf("ERROR: nsqd %s - %s", endpoint, err)
 				return
@@ -391,7 +395,7 @@ func (c *ClusterInfo) GetNSQDTopicProducers(topic string, nsqdHTTPAddrs []string
 			c.logf("NSQD: querying %s", endpoint)
 
 			var statsResp statsRespType
-			err := http_api.NegotiateV1(endpoint, &statsResp)
+			err := c.client.NegotiateV1(endpoint, &statsResp)
 			if err != nil {
 				c.logf("ERROR: nsqd %s - %s", endpoint, err)
 				return
@@ -412,7 +416,7 @@ func (c *ClusterInfo) GetNSQDTopicProducers(topic string, nsqdHTTPAddrs []string
 					c.logf("NSQD: querying %s", endpoint)
 
 					var infoResp infoRespType
-					err := http_api.NegotiateV1(endpoint, &infoResp)
+					err := c.client.NegotiateV1(endpoint, &infoResp)
 					if err != nil {
 						c.logf("ERROR: nsqd %s - %s", endpoint, err)
 						return
@@ -472,7 +476,7 @@ func (c *ClusterInfo) GetNSQDStats(producerList ProducerList, selectedTopic stri
 			defer wg.Done()
 
 			var resp respType
-			err := http_api.NegotiateV1(endpoint, &resp)
+			err := c.client.NegotiateV1(endpoint, &resp)
 			if err != nil {
 				c.logf("ERROR: lookupd %s - %s", endpoint, err)
 				return

--- a/internal/http_api/http_server.go
+++ b/internal/http_api/http_server.go
@@ -2,6 +2,7 @@ package http_api
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -9,11 +10,21 @@ import (
 	"github.com/bitly/nsq/internal/app"
 )
 
+type logWriter struct {
+	app.Logger
+}
+
+func (l logWriter) Write(p []byte) (int, error) {
+	l.Logger.Output(2, string(p))
+	return len(p), nil
+}
+
 func Serve(listener net.Listener, handler http.Handler, proto string, l app.Logger) {
 	l.Output(2, fmt.Sprintf("%s: listening on %s", proto, listener.Addr()))
 
 	server := &http.Server{
-		Handler: handler,
+		Handler:  handler,
+		ErrorLog: log.New(logWriter{l}, "", 0),
 	}
 	err := server.Serve(listener)
 	// theres no direct way to detect this error because it is not exposed

--- a/nsqadmin/nsqadmin.go
+++ b/nsqadmin/nsqadmin.go
@@ -2,8 +2,11 @@ package nsqadmin
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,11 +21,12 @@ import (
 
 type NSQAdmin struct {
 	sync.RWMutex
-	opts          *Options
-	httpListener  net.Listener
-	waitGroup     util.WaitGroupWrapper
-	notifications chan *AdminAction
-	graphiteURL   *url.URL
+	opts                *Options
+	httpListener        net.Listener
+	waitGroup           util.WaitGroupWrapper
+	notifications       chan *AdminAction
+	graphiteURL         *url.URL
+	httpClientTLSConfig *tls.Config
 }
 
 func New(opts *Options) *NSQAdmin {
@@ -49,6 +53,43 @@ func New(opts *Options) *NSQAdmin {
 			os.Exit(1)
 		}
 		return addr
+	}
+
+	if opts.HTTPClientTLSCert != "" && opts.HTTPClientTLSKey == "" {
+		n.logf("FATAL: --http-client-tls-key must be specified with --http-client-tls-cert")
+		os.Exit(1)
+	}
+
+	if opts.HTTPClientTLSKey != "" && opts.HTTPClientTLSCert == "" {
+		n.logf("FATAL: --http-client-tls-cert must be specified with --http-client-tls-key")
+		os.Exit(1)
+	}
+
+	n.httpClientTLSConfig = &tls.Config{
+		InsecureSkipVerify: opts.HTTPClientTLSInsecureSkipVerify,
+	}
+	if opts.HTTPClientTLSCert != "" && opts.HTTPClientTLSKey != "" {
+		cert, err := tls.LoadX509KeyPair(opts.HTTPClientTLSCert, opts.HTTPClientTLSKey)
+		if err != nil {
+			n.logf("FATAL: failed to LoadX509KeyPair %s, %s - %s",
+				opts.HTTPClientTLSCert, opts.HTTPClientTLSKey, err)
+			os.Exit(1)
+		}
+		n.httpClientTLSConfig.Certificates = []tls.Certificate{cert}
+	}
+	if opts.HTTPClientTLSRootCAFile != "" {
+		tlsCertPool := x509.NewCertPool()
+		caCertFile, err := ioutil.ReadFile(opts.HTTPClientTLSRootCAFile)
+		if err != nil {
+			n.logf("FATAL: failed to read TLS root CA file %s - %s",
+				opts.HTTPClientTLSRootCAFile, err)
+			os.Exit(1)
+		}
+		if !tlsCertPool.AppendCertsFromPEM(caCertFile) {
+			n.logf("FATAL: failed to AppendCertsFromPEM %s", opts.HTTPClientTLSRootCAFile)
+			os.Exit(1)
+		}
+		n.httpClientTLSConfig.ClientCAs = tlsCertPool
 	}
 
 	// require that both the hostname and port be specified

--- a/nsqadmin/options.go
+++ b/nsqadmin/options.go
@@ -19,6 +19,11 @@ type Options struct {
 	NSQLookupdHTTPAddresses []string `flag:"lookupd-http-address" cfg:"nsqlookupd_http_addresses"`
 	NSQDHTTPAddresses       []string `flag:"nsqd-http-address" cfg:"nsqd_http_addresses"`
 
+	HTTPClientTLSInsecureSkipVerify bool   `flag:"http-client-tls-insecure-skip-verify"`
+	HTTPClientTLSRootCAFile         string `flag:"http-client-tls-root-ca-file"`
+	HTTPClientTLSCert               string `flag:"http-client-tls-cert"`
+	HTTPClientTLSKey                string `flag:"http-client-tls-key"`
+
 	NotificationHTTPEndpoint string `flag:"notification-http-endpoint"`
 
 	Logger logger

--- a/nsqd/http.go
+++ b/nsqd/http.go
@@ -106,7 +106,9 @@ func newHTTPServer(ctx *context, tlsEnabled bool, tlsRequired bool) *httpServer 
 
 func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if !s.tlsEnabled && s.tlsRequired {
-		http_api.Respond(w, 403, "TLS_REQUIRED", nil)
+		resp := fmt.Sprintf(`{"message": "TLS_REQUIRED", "https_port": %d}`,
+			s.ctx.nsqd.RealHTTPSAddr().Port)
+		http_api.Respond(w, 403, "", resp)
 		return
 	}
 	s.router.ServeHTTP(w, req)

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -162,6 +162,12 @@ func (n *NSQD) RealHTTPAddr() *net.TCPAddr {
 	return n.httpListener.Addr().(*net.TCPAddr)
 }
 
+func (n *NSQD) RealHTTPSAddr() *net.TCPAddr {
+	n.RLock()
+	defer n.RUnlock()
+	return n.httpsListener.Addr().(*net.TCPAddr)
+}
+
 func (n *NSQD) setFlag(f int32, b bool) {
 	for {
 		old := atomic.LoadInt32(&n.flag)

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -79,7 +79,7 @@ func New(opts *Options) *NSQD {
 		exitChan:             make(chan int),
 		notifyChan:           make(chan interface{}),
 		optsNotificationChan: make(chan struct{}, 1),
-		ci:                   clusterinfo.New(opts.Logger),
+		ci:                   clusterinfo.New(opts.Logger, http_api.NewClient(nil)),
 	}
 	n.swapOpts(opts)
 

--- a/nsqd/nsqd_test.go
+++ b/nsqd/nsqd_test.go
@@ -78,7 +78,7 @@ func getMetadata(n *NSQD) (*simplejson.Json, error) {
 
 func API(endpoint string) (data *simplejson.Json, err error) {
 	d := make(map[string]interface{})
-	err = http_api.NegotiateV1(endpoint, &d)
+	err = http_api.NewClient(nil).NegotiateV1(endpoint, &d)
 	data = simplejson.New()
 	data.SetPath(nil, d)
 	return
@@ -361,11 +361,11 @@ func TestCluster(t *testing.T) {
 	equal(t, err, nil)
 
 	url := fmt.Sprintf("http://%s/topic/create?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.POSTV1(url)
+	err = http_api.NewClient(nil).POSTV1(url)
 	equal(t, err, nil)
 
 	url = fmt.Sprintf("http://%s/channel/create?topic=%s&channel=ch", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.POSTV1(url)
+	err = http_api.NewClient(nil).POSTV1(url)
 	equal(t, err, nil)
 
 	// allow some time for nsqd to push info to nsqlookupd
@@ -413,7 +413,7 @@ func TestCluster(t *testing.T) {
 	equal(t, channel, "ch")
 
 	url = fmt.Sprintf("http://%s/topic/delete?topic=%s", nsqd.RealHTTPAddr(), topicName)
-	err = http_api.POSTV1(url)
+	err = http_api.NewClient(nil).POSTV1(url)
 	equal(t, err, nil)
 
 	// allow some time for nsqd to push info to nsqlookupd

--- a/nsqlookupd/nsqlookupd_test.go
+++ b/nsqlookupd/nsqlookupd_test.go
@@ -74,7 +74,7 @@ func identify(t *testing.T, conn net.Conn, address string, tcpPort int, httpPort
 
 func API(endpoint string) (data *simplejson.Json, err error) {
 	d := make(map[string]interface{})
-	err = http_api.NegotiateV1(endpoint, &d)
+	err = http_api.NewClient(nil).NegotiateV1(endpoint, &d)
 	data = simplejson.New()
 	data.SetPath(nil, d)
 	return
@@ -254,7 +254,7 @@ func TestTombstoneRecover(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.POSTV1(endpoint)
+	err = http_api.NewClient(nil).POSTV1(endpoint)
 	equal(t, err, nil)
 
 	endpoint = fmt.Sprintf("http://%s/lookup?topic=%s", httpAddr, topicName)
@@ -298,7 +298,7 @@ func TestTombstoneUnregister(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.POSTV1(endpoint)
+	err = http_api.NewClient(nil).POSTV1(endpoint)
 	equal(t, err, nil)
 
 	endpoint = fmt.Sprintf("http://%s/lookup?topic=%s", httpAddr, topicName)
@@ -340,7 +340,9 @@ func TestInactiveNodes(t *testing.T) {
 	_, err := nsq.ReadResponse(conn)
 	equal(t, err, nil)
 
-	producers, _ := clusterinfo.New(nil).GetLookupdProducers(lookupdHTTPAddrs)
+	ci := clusterinfo.New(nil, http_api.NewClient(nil))
+
+	producers, _ := ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 1)
 	equal(t, len(producers[0].Topics), 1)
 	equal(t, producers[0].Topics[0].Topic, topicName)
@@ -348,7 +350,7 @@ func TestInactiveNodes(t *testing.T) {
 
 	time.Sleep(250 * time.Millisecond)
 
-	producers, _ = clusterinfo.New(nil).GetLookupdProducers(lookupdHTTPAddrs)
+	producers, _ = ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 0)
 }
 
@@ -371,7 +373,9 @@ func TestTombstonedNodes(t *testing.T) {
 	_, err := nsq.ReadResponse(conn)
 	equal(t, err, nil)
 
-	producers, _ := clusterinfo.New(nil).GetLookupdProducers(lookupdHTTPAddrs)
+	ci := clusterinfo.New(nil, http_api.NewClient(nil))
+
+	producers, _ := ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 1)
 	equal(t, len(producers[0].Topics), 1)
 	equal(t, producers[0].Topics[0].Topic, topicName)
@@ -379,10 +383,10 @@ func TestTombstonedNodes(t *testing.T) {
 
 	endpoint := fmt.Sprintf("http://%s/topic/tombstone?topic=%s&node=%s",
 		httpAddr, topicName, "ip.address:5555")
-	err = http_api.POSTV1(endpoint)
+	err = http_api.NewClient(nil).POSTV1(endpoint)
 	equal(t, err, nil)
 
-	producers, _ = clusterinfo.New(nil).GetLookupdProducers(lookupdHTTPAddrs)
+	producers, _ = ci.GetLookupdProducers(lookupdHTTPAddrs)
 	equal(t, len(producers), 1)
 	equal(t, len(producers[0].Topics), 1)
 	equal(t, producers[0].Topics[0].Topic, topicName)


### PR DESCRIPTION
From https://groups.google.com/d/msg/nsq-users/PkkPN9z7gPc/6EgTyHmuvg0J

`nsqadmin` cannot correctly negotiate TLS when `nsqd` in the cluster are configured with `--tls-required`.

Not sure yet how to fix this, some thoughts:

1. `nsqadmin` needs to be able to specify scheme in the `--nsqd-http-address` flag
2. `nsqd` needs to propagate TLS status to `nsqlookupd`, which needs to return this in its API responses
3. `nsqadmin` will pivot on (1) and (2) to negotiate which scheme to use

Thoughts @jehiah?